### PR TITLE
Use TC linting rules

### DIFF
--- a/packages/react-scripts/.eslintrc
+++ b/packages/react-scripts/.eslintrc
@@ -1,3 +1,3 @@
 {
-  "extends": "react-app"
+  "extends": "@trunkclub/eslint-config"
 }

--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -173,6 +173,9 @@ module.exports = {
   // Point ESLint to our predefined config.
   eslint: {
     configFile: path.join(__dirname, '../.eslintrc'),
+    // All warnings and errors are passed to webpack as warnings to allow
+    // webpack compilation to continue.
+    emitWarning: true,
     useEslintrc: false
   },
   // @remove-on-eject-end

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -186,6 +186,7 @@ module.exports = {
     // TODO: consider separate config for production,
     // e.g. to enable no-console and no-debugger only in production.
     configFile: path.join(__dirname, '../.eslintrc'),
+    emitError: true,
     useEslintrc: false
   },
   // @remove-on-eject-end

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -186,7 +186,6 @@ module.exports = {
     // TODO: consider separate config for production,
     // e.g. to enable no-console and no-debugger only in production.
     configFile: path.join(__dirname, '../.eslintrc'),
-    emitError: true,
     useEslintrc: false
   },
   // @remove-on-eject-end

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -21,8 +21,7 @@
     "utils"
   ],
   "bin": {
-    "react-scripts": "./bin/react-scripts.js",
-    "tcweb-build": "./bin/react-scripts.js"
+    "react-scripts": "./bin/react-scripts.js"
   },
   "dependencies": {
     "@trunkclub/eslint-config": "2.0.0-alpha.1",

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trunkclub/build",
-  "version": "5.0.0-alpha.1",
+  "version": "5.0.0-alpha.2",
   "upstream-version": "0.7.0",
   "description": "Configuration and scripts for Create React App. Fork maintained by Trunk Club",
   "repository": "trunkclub/create-react-app",
@@ -24,7 +24,7 @@
     "react-scripts": "./bin/react-scripts.js"
   },
   "dependencies": {
-    "@trunkclub/eslint-config": "2.0.0-alpha.1",
+    "@trunkclub/eslint-config": "2.0.0-alpha.2",
     "autoprefixer": "6.5.1",
     "babel-core": "6.17.0",
     "babel-eslint": "7.0.0",

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@trunkclub/react-scripts",
-  "version": "1.1.2",
+  "name": "@trunkclub/build",
+  "version": "5.0.0-alpha.1",
   "upstream-version": "0.7.0",
   "description": "Configuration and scripts for Create React App. Fork maintained by Trunk Club",
   "repository": "trunkclub/create-react-app",
@@ -21,9 +21,11 @@
     "utils"
   ],
   "bin": {
-    "react-scripts": "./bin/react-scripts.js"
+    "react-scripts": "./bin/react-scripts.js",
+    "tcweb-build": "./bin/react-scripts.js"
   },
   "dependencies": {
+    "@trunkclub/eslint-config": "2.0.0-alpha.1",
     "autoprefixer": "6.5.1",
     "babel-core": "6.17.0",
     "babel-eslint": "7.0.0",
@@ -38,11 +40,9 @@
     "detect-port": "1.0.1",
     "dotenv": "2.0.0",
     "eslint": "3.8.1",
-    "eslint-config-react-app": "^0.3.0",
     "eslint-loader": "1.6.0",
-    "eslint-plugin-flowtype": "2.21.0",
+    "eslint-plugin-flowtype-errors": "^1.5.0",
     "eslint-plugin-import": "2.0.1",
-    "eslint-plugin-jsx-a11y": "2.2.3",
     "eslint-plugin-react": "6.4.1",
     "extract-text-webpack-plugin": "1.0.1",
     "file-loader": "0.9.0",
@@ -82,6 +82,7 @@
     "fsevents": "1.0.14"
   },
   "bundledDependencies": [
+    "@trunkclub/eslint-config",
     "autoprefixer",
     "babel-core",
     "babel-eslint",
@@ -96,11 +97,9 @@
     "detect-port",
     "dotenv",
     "eslint",
-    "eslint-config-react-app",
     "eslint-loader",
     "eslint-plugin-flowtype",
-    "eslint-plugin-import",
-    "eslint-plugin-jsx-a11y",
+    "eslint-plugin-flowtype-errors",
     "eslint-plugin-react",
     "extract-text-webpack-plugin",
     "file-loader",


### PR DESCRIPTION
Related to https://github.com/trunkclub/tcweb-eslint-config/pull/2

This points the `eslint-loader` to our eslint configuration instead of the one that comes with `react-scripts` and makes warnings errors in the production builds.

@trunkclub/ui 
