### PR TITLE
Add support for using `src/index.es6`

### DIFF
--- a/packages/react-scripts/config/paths.js
+++ b/packages/react-scripts/config/paths.js
@@ -40,7 +40,9 @@ module.exports = {
   appBuild: resolveApp('build'),
   appPublic: resolveApp('public'),
   appHtml: resolveApp('public/index.html'),
-  appIndexJs: resolveApp('src/index.js'),
+  appIndexJs: fs.existsSync(resolveApp('src/index.es6'))
+                ? resolveApp('src/index.es6')
+                : resolveApp('src/index.js'),
   appPackageJson: resolveApp('package.json'),
   appSrc: resolveApp('src'),
   testsSetup: resolveApp('src/setupTests.js'),
@@ -59,7 +61,9 @@ module.exports = {
   appBuild: resolveApp('build'),
   appPublic: resolveApp('public'),
   appHtml: resolveApp('public/index.html'),
-  appIndexJs: resolveApp('src/index.js'),
+  appIndexJs: fs.existsSync(resolveApp('src/index.es6'))
+                ? resolveApp('src/index.es6')
+                : resolveApp('src/index.js'),
   appPackageJson: resolveApp('package.json'),
   appSrc: resolveApp('src'),
   testsSetup: resolveApp('src/setupTests.js'),

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trunkclub/build",
-  "version": "5.0.0-alpha.2",
+  "version": "5.0.0-alpha.3",
   "upstream-version": "0.7.0",
   "description": "Configuration and scripts for Create React App. Fork maintained by Trunk Club",
   "repository": "trunkclub/create-react-app",


### PR DESCRIPTION
I don't want to force people to change what extension their using for their JS/ECMAScript files so this will use an `src/index.es6` if it's there but will attempt to use `src/index.js` if it is not.

Fixes #11 

@trunkclub/ui 
