### PR TITLE
Fix bug in scoped/versioned package name parsing

### DIFF
--- a/packages/create-react-app/index.js
+++ b/packages/create-react-app/index.js
@@ -156,7 +156,7 @@ function getPackageName(installPackage) {
     // The package name could be with or without semver version, e.g. react-scripts-0.2.0-alpha.1.tgz
     // However, this function returns package name only wihout semver version.
     return installPackage.match(/^.+\/(.+?)(?:-\d+.+)?\.tgz$/)[1];
-  } else if (installPackage.indexOf('@') > 0) {
+  } else if (installPackage.indexOf('@') > -1) {
     // Do not match @scope/ when stripping off @version or @tag
     return installPackage.charAt(0) + installPackage.substr(1).split('@')[0];
   }


### PR DESCRIPTION
Index of the '@' character on a scoped package will be 0, so we
should instead check that it's greater than -1

@zperrault 