### PR TITLE
Update flow-bin and eslint config

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trunkclub/build",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "upstream-version": "0.7.0",
   "description": "Configuration and scripts for Create React App. Fork maintained by Trunk Club",
   "repository": "trunkclub/create-react-app",
@@ -29,7 +29,7 @@
     "tcweb-build": "./bin/react-scripts.js"
   },
   "dependencies": {
-    "@trunkclub/eslint-config": "2.0.0",
+    "@trunkclub/eslint-config": "2.1.0",
     "@trunkclub/react-dev-utils": "1.0.0",
     "autoprefixer": "6.5.1",
     "babel-cli": "6.18.0",
@@ -51,11 +51,12 @@
     "dotenv": "2.0.0",
     "eslint": "3.8.1",
     "eslint-loader": "1.6.0",
-    "eslint-plugin-flowtype-errors": "1.5.0",
+    "eslint-plugin-flowtype-errors": "2.0.0-0",
     "eslint-plugin-react": "6.4.1",
     "extract-text-webpack-plugin": "1.0.1",
     "file-loader": "0.9.0",
     "filesize": "3.3.0",
+    "flow-bin": "0.35.0",
     "fs-extra": "0.30.0",
     "gzip-size": "3.0.0",
     "happypack": "2.2.1",


### PR DESCRIPTION
Uses the new `@trunkclub/eslint-config` which allows specifying the flow version. Getting versions to match here and globally on our dev machines should make editor integration a lot smoother.

@trunkclub/ui 