### PR TITLE
Add source-map-loader for trunkclub modules

### DIFF
--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -98,8 +98,16 @@ module.exports = {
   // @remove-on-eject-end
   module: {
     noParse: [/\.elm$/],
-    // First, run the linter.
-    // It's important to do this before Babel processes the JS.
+    preLoaders: [{
+      loader: 'source-map',
+      test: /\.(jsx?|es6)$/,
+      include: function (abs) {
+        const rel = path.relative(paths.appSrc, abs)
+        return (/@trunkclub/.test(rel) ||
+                /trunkclub-web/.test(rel) ||
+                /tcweb-/.test(rel))
+      }
+    }],
     loaders: [
       // Default loader: load all assets that are not handled
       // by other loaders with the url loader.

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -124,6 +124,15 @@ module.exports = {
         test: /\.(js|jsx|es6)$/,
         loader: 'eslint',
         include: paths.appSrc
+      }, {
+        loader: 'source-map',
+        test: /\.(jsx?|es6)$/,
+        include: function (abs) {
+          const rel = path.relative(paths.appSrc, abs)
+          return (/@trunkclub/.test(rel) ||
+                  /trunkclub-web/.test(rel) ||
+                  /tcweb-/.test(rel))
+        }
       }
     ],
     loaders: [

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trunkclub/build",
-  "version": "5.4.1",
+  "version": "5.5.0",
   "upstream-version": "0.8.1",
   "description": "Configuration and scripts for Create React App. Fork maintained by Trunk Club",
   "repository": "trunkclub/create-react-app",

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -77,6 +77,7 @@
     "recursive-readdir": "2.1.0",
     "rimraf": "2.5.4",
     "sass-loader": "4.0.2",
+    "source-map-loader": "0.1.5",
     "strip-ansi": "3.0.1",
     "style-loader": "0.13.1",
     "url-loader": "0.5.7",


### PR DESCRIPTION
The source map loader reads source maps (external or inline) and adds them to the internal webpack pipeline.

This is using a heuristic to only include our modules because reading source maps can be slow.

@trunkclub/ui 

🙏  @littleredninja 🙏  I know you've been asking for this for months now 😥 