### PR TITLE
Removes unused `react-hot-loader` transform

### DIFF
--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -49,7 +49,6 @@ module.exports = {
     // the line below with these two lines if you prefer the stock client:
     // require.resolve('webpack-dev-server/client') + '?/',
     // require.resolve('webpack/hot/dev-server'),
-    require.resolve('react-hot-loader/patch'),
     require.resolve('@trunkclub/react-dev-utils/webpackHotDevClient'),
     // We ship a few polyfills by default:
     require.resolve('babel-polyfill'),
@@ -237,7 +236,6 @@ module.exports = {
         query: {
           // @remove-on-eject-begin
           babelrc: false,
-          plugins: [require.resolve('react-hot-loader/babel')],
           presets: [require.resolve('babel-preset-trunkclub')],
           // @remove-on-eject-end
           // This is a feature of `babel-loader` for webpack (not Babel itself).

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trunkclub/build",
-  "version": "5.5.2",
+  "version": "5.5.3",
   "upstream-version": "0.8.1",
   "description": "Configuration and scripts for Create React App. Fork maintained by Trunk Club",
   "repository": "trunkclub/create-react-app",

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -73,7 +73,6 @@
     "progress-bar-webpack-plugin": "1.9.0",
     "promise": "7.1.1",
     "react-dev-utils": "^0.4.0",
-    "react-hot-loader": "3.0.0-beta.6",
     "recursive-readdir": "2.1.0",
     "rimraf": "2.5.4",
     "sass-loader": "4.0.2",


### PR DESCRIPTION
FYI @trunkclub/ui 


This isn't being used in any apps right now (and isn't stable yet 😞 )