### PR TITLE
Only include `en` locale from moment.

### DIFF
--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -239,6 +239,7 @@ module.exports = {
     // a plugin that prints an error when you attempt to do this.
     // See https://github.com/facebookincubator/create-react-app/issues/240
     new CaseSensitivePathsPlugin(),
+    new webpack.ContextReplacementPlugin(/moment[\\\/]locale$/, /^\.\/en$/),
     // If you require a missing module and then `npm install` it, you still have
     // to restart the development server for Webpack to discover it. This plugin
     // makes the discovery automatic so you don't have to restart.

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -295,6 +295,7 @@ module.exports = {
     }),
     // Note: this won't work without ExtractTextPlugin.extract(..) in `loaders`.
     new ExtractTextPlugin('static/css/[name].[contenthash:8].css'),
+    new webpack.ContextReplacementPlugin(/moment[\\\/]locale$/, /^\.\/en$/),
     // Generate a manifest file which contains a mapping of all asset filenames
     // to their corresponding output file so that tools can pick it up without
     // having to parse `index.html`.

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trunkclub/build",
-  "version": "5.7.0",
+  "version": "5.7.1",
   "upstream-version": "0.8.4",
   "description": "Configuration and scripts for Create React App. Fork maintained by Trunk Club",
   "repository": "trunkclub/create-react-app",


### PR DESCRIPTION
( Straight copy 🍝  from https://github.com/trunkclub/tcweb-build-old/pull/19 )

## What?

By default, when imported within a webpack context, moment includes _all_ of its locale data. We only support a single locale so this prunes off all of that unused code 🎉 

## Control:

![image](https://cloud.githubusercontent.com/assets/1699281/21240892/e1635b1e-c2d2-11e6-92eb-c5dc11c14366.png)


## Test:

![image](https://cloud.githubusercontent.com/assets/1699281/21240904/f024cdb8-c2d2-11e6-8d4b-46179d25e046.png)

That's a reduction of *355.47%!!!*
