### PR TITLE
Alias react

### DIFF
--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -82,6 +82,9 @@ module.exports = {
     // https://github.com/facebookincubator/create-react-app/issues/290
     extensions: ['.js', '.json', '.jsx', '.es6', '.coffee', '.cjsx', ''],
     alias: {
+      // This will prevent the multiple React instances issue (invariant). This mostly
+      // occurs when locally linking another npm package that requires React.
+      react: path.resolve(paths.appNodeModules, 'react'),
       // Support React Native Web
       // https://www.smashingmagazine.com/2016/08/a-glimpse-into-the-future-with-react-native-for-web/
       'react-native': 'react-native-web'

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trunkclub/build",
-  "version": "5.7.1",
+  "version": "5.8.0",
   "upstream-version": "0.8.4",
   "description": "Configuration and scripts for Create React App. Fork maintained by Trunk Club",
   "repository": "trunkclub/create-react-app",


### PR DESCRIPTION
Sometimes, when locally linking another npm package that also depends on React, it will break the runtime because more than one React instance is available.

This will alias React to the project's root node_modules directory, forcing nested modules to all use the same React import.

@zperrault @jblock 