### PR TITLE
Update webpack config to resolve loaders identically in dev & prod

### DIFF
--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -108,7 +108,6 @@ module.exports = {
   // directory of `react-scripts` itself rather than the project directory.
   resolveLoader: {
     root: paths.ownNodeModules,
-    moduleTemplates: ['*-loader']
   },
   // @remove-on-eject-end
   module: {

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trunkclub/build",
-  "version": "5.8.0",
+  "version": "5.8.1",
   "upstream-version": "0.8.4",
   "description": "Configuration and scripts for Create React App. Fork maintained by Trunk Club",
   "repository": "trunkclub/create-react-app",


### PR DESCRIPTION
Loaders were being found with the dev config, but not the production config. This updates production to resolve loaders identical to that of the development config.

@wSnarski @jblock @zperrault 