### PR TITLE
Add fallback for resolving loaders

### DIFF
--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -148,7 +148,7 @@ module.exports = {
           /\.elm$/,
           /\.svg$/
         ],
-        loader: 'url',
+        loader: 'url-loader',
         query: {
           limit: 10000,
           name: 'static/media/[name].[hash:8].[ext]'
@@ -158,7 +158,7 @@ module.exports = {
       {
         test: /\.(js|jsx|es6)$/,
         include: paths.appSrc,
-        loader: 'babel',
+        loader: 'babel-loader',
         query: {
           // @remove-on-eject-begin
           babelrc: false,
@@ -173,12 +173,12 @@ module.exports = {
       {
         test: /\.elm/,
         include: paths.appSrc,
-        loader: 'elm-webpack'
+        loader: 'elm-webpack-loader'
       },
       {
         test: /\.(coffee|cjsx)$/,
         include: paths.appSrc,
-        loaders: ['coffee', 'cjsx']
+        loaders: ['coffee-loader', 'cjsx-loader']
       },
       // "postcss" loader applies autoprefixer to our CSS.
       // "css" loader resolves paths in CSS and adds assets as dependencies.
@@ -187,18 +187,18 @@ module.exports = {
       // in development "style" loader enables hot editing of CSS.
       {
         test: /\.s?css$/,
-        loader: 'style!css?importLoaders=1&sourceMap!postcss!sass?sourceMap'
+        loader: 'style-loader!css-loader?importLoaders=1&sourceMap!postcss-loader!sass-loader?sourceMap'
       },
       // JSON is not enabled by default in Webpack but both Node and Browserify
       // allow it implicitly so we also enable it.
       {
         test: /\.json$/,
-        loader: 'json'
+        loader: 'json-loader'
       },
       // "file" loader for svg
       {
         test: /\.svg$/,
-        loader: 'file',
+        loader: 'file-loader',
         query: {
           name: 'static/media/[name].[hash:8].[ext]'
         }

--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -95,13 +95,14 @@ module.exports = {
   // directory of `react-scripts` itself rather than the project directory.
   resolveLoader: {
     root: paths.ownNodeModules,
+    fallback: paths.appNodeModules,
   },
   // @remove-on-eject-end
   module: {
     noParse: [/\.elm$/],
     preLoaders: [
       {
-        loader: 'source-map',
+        loader: 'source-map-loader',
         test: /\.(jsx?|es6)$/,
         include: function (abs) {
           const rel = path.relative(paths.appSrc, abs)
@@ -109,7 +110,7 @@ module.exports = {
         }
       },
       {
-        loader: 'eslint',
+        loader: 'eslint-loader',
         test: /\.(jsx?|es6)$/,
         include: paths.appSrc,
         query: {

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -108,6 +108,7 @@ module.exports = {
   // directory of `react-scripts` itself rather than the project directory.
   resolveLoader: {
     root: paths.ownNodeModules,
+    fallback: paths.appNodeModules,
   },
   // @remove-on-eject-end
   module: {
@@ -117,10 +118,10 @@ module.exports = {
     preLoaders: [
       {
         test: /\.(js|jsx|es6)$/,
-        loader: 'eslint',
+        loader: 'eslint-loader',
         include: paths.appSrc
       }, {
-        loader: 'source-map',
+        loader: 'source-map-loader',
         test: /\.(jsx?|es6)$/,
         include: function (abs) {
           const rel = path.relative(paths.appSrc, abs)

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -153,7 +153,7 @@ module.exports = {
           /\.elm$/,
           /\.svg$/
         ],
-        loader: 'url',
+        loader: 'url-loader',
         query: {
           limit: 10000,
           name: 'static/media/[name].[hash:8].[ext]'
@@ -163,7 +163,7 @@ module.exports = {
       {
         test: /\.(js|jsx|es6)$/,
         include: paths.appSrc,
-        loader: 'babel',
+        loader: 'babel-loader',
         // @remove-on-eject-begin
         query: {
           babelrc: false,
@@ -174,12 +174,12 @@ module.exports = {
       {
         test: /\.elm/,
         include: paths.appSrc,
-        loader: 'elm-webpack'
+        loader: 'elm-webpack-loader'
       },
       {
         test: /\.(coffee|cjsx)$/,
         include: paths.appSrc,
-        loaders: ['coffee', 'cjsx']
+        loaders: ['coffee-loader', 'cjsx-loader']
       },
       // The notation here is somewhat confusing.
       // "postcss" loader applies autoprefixer to our CSS.
@@ -203,19 +203,19 @@ module.exports = {
         // Webpack 1.x uses Uglify plugin as a signal to minify *all* the assets
         // including CSS. This is confusing and will be removed in Webpack 2:
         // https://github.com/webpack/webpack/issues/283
-        loader: ExtractTextPlugin.extract('style', 'css?importLoaders=1&sourceMap!postcss!sass?sourceMap')
+        loader: ExtractTextPlugin.extract('style-loader', 'css-loader?importLoaders=1&sourceMap!postcss-loader!sass-loader?sourceMap')
         // Note: this won't work without `new ExtractTextPlugin()` in `plugins`.
       },
       // JSON is not enabled by default in Webpack but both Node and Browserify
       // allow it implicitly so we also enable it.
       {
         test: /\.json$/,
-        loader: 'json'
+        loader: 'json-loader'
       },
       // "file" loader for svg
       {
         test: /\.svg$/,
-        loader: 'file',
+        loader: 'file-loader',
         query: {
           name: 'static/media/[name].[hash:8].[ext]'
         }

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trunkclub/build",
-  "version": "5.8.1",
+  "version": "5.8.2",
   "upstream-version": "0.8.4",
   "description": "Configuration and scripts for Create React App. Fork maintained by Trunk Club",
   "repository": "trunkclub/create-react-app",


### PR DESCRIPTION
With npm3 and Yarn, nested dependencies are pulled into the app's root node_modules folder. The webpack config is set to look for its loaders from its own modules folder.

Usually it doesn't have an issue locating it the app's module folder, however sometimes when a project is locally linked, it cannot find them anymore.

This tells the config to look in the app's module folder as a fallback, which seems to remedy the issue.

@zperrault @eanplatter @alexbartling 