### PR TITLE
Export `TC_ENV` within apps

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trunkclub/build",
-  "version": "5.8.2",
+  "version": "5.9.0",
   "upstream-version": "0.8.4",
   "description": "Configuration and scripts for Create React App. Fork maintained by Trunk Club",
   "repository": "trunkclub/create-react-app",

--- a/packages/react-scripts/utils/loadEnv.js
+++ b/packages/react-scripts/utils/loadEnv.js
@@ -6,6 +6,11 @@ var dotenv = require('dotenv');
 var env = process.env.NODE_ENV;
 var appDirectory = fs.realpathSync(process.cwd());
 
+// CRA assumes two environments: development or production.
+// There are some scenarios where we need to explicitly know that
+// we are in a staging environment.
+process.env.TC_ENV = env;
+
 // dotenv will not change values that are already set, sourcing the
 // overrides firsts means they will beat anything in the default
 // [process.env.NODE_ENV].env file.


### PR DESCRIPTION
There are a few cases where we need to know whether we are in a staging environment or not. CRA assumes 2 environments: `development` and `production`, so this would export a separate variable that we can use when we _need_ that nuance.

For most situations, the two environments are sufficiently distinct. 

@zperrault @iamlacroix @eanplatter ? 