### PR TITLE
Enable CSS Modules

### DIFF
--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -185,8 +185,16 @@ module.exports = {
       // "style" loader turns CSS into JS modules that inject <style> tags.
       // In production, we use a plugin to extract that CSS to a file, but
       // in development "style" loader enables hot editing of CSS.
+      // If a file is named [FILE].module.s?css instead of [FILE].s?css
+      // then we will process it as a CSS Module (https://github.com/css-modules/css-modules).
       {
+        test: /\.module\.s?css$/,
+        loader: 'style-loader!css-loader?importLoaders=1&modules&localIdentName=[path][name]__[local]--[hash:base64:8]&sourceMap!postcss-loader!sass-loader?sourceMap'
+      },
+      {
+        /* test: /(?<!\.module)\.s?css$/,*/
         test: /\.s?css$/,
+        exclude: /\.module\.s?css$/,
         loader: 'style-loader!css-loader?importLoaders=1&sourceMap!postcss-loader!sass-loader?sourceMap'
       },
       // JSON is not enabled by default in Webpack but both Node and Browserify

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trunkclub/build",
-  "version": "5.9.0",
+  "version": "5.10.0-beta.1",
   "upstream-version": "0.8.4",
   "description": "Configuration and scripts for Create React App. Fork maintained by Trunk Club",
   "repository": "trunkclub/create-react-app",


### PR DESCRIPTION
Enables CSS Modules for CSS or Sass files that are named with a `.module` prefix before the file extension, e.g. `MyComponent.module.scss`.

The CSS modules will be extracted to the same stylesheet file as the non-module CSS. For now, we are using the same identifier scheme for both dev and production:

```
localIdentName=[path][name]__[local]--[hash:base64:8]
```

Given an example class name of `.title` in a file `src/components/MyComponent.module.scss`, it will produce a class name like:

```
.src-MyComponent-module__title--xz9uia4s
```

You can test it out in your apps by using the beta tag `npm install @trunkclub/build@beta`.

@zperrault @eanplatter @littleredninja @jblock 