### PR TITLE
Build module extension handling

### DIFF
--- a/packages/react-scripts/config/env.js
+++ b/packages/react-scripts/config/env.js
@@ -12,9 +12,6 @@
 // Grab NODE_ENV and TC_* environment variables and prepare them to be
 // injected into the application via DefinePlugin in Webpack configuration.
 
-var paths = require('./paths');
-var pkg = require(paths.appPackageJson);
-var git = require('git-rev-sync');
 var REACT_APP = /^(TC_|PORT)/i;
 
 function getClientEnvironment(publicUrl) {
@@ -35,10 +32,6 @@ function getClientEnvironment(publicUrl) {
       // This should only be used as an escape hatch. Normally you would put
       // images into the `src` and `import` them in code to get their paths.
       'PUBLIC_URL': JSON.stringify(publicUrl),
-
-      'TC_CLIENT_APP_NAME': JSON.stringify(pkg.name),
-      'TC_CLIENT_BUILD_COMMIT': JSON.stringify(git.long()),
-      'TC_CLIENT_BUILD_TIME': JSON.stringify((new Date()).toISOString())
     });
   return {'process.env': processEnv};
 }

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trunkclub/build",
-  "version": "5.10.0-beta.1",
+  "version": "5.10.0",
   "upstream-version": "0.8.4",
   "description": "Configuration and scripts for Create React App. Fork maintained by Trunk Club",
   "repository": "trunkclub/create-react-app",

--- a/packages/react-scripts/scripts/build-module.js
+++ b/packages/react-scripts/scripts/build-module.js
@@ -24,7 +24,13 @@ function transformWithBabel (filePath) {
       }]
     ]
   });
-  fs.writeFileSync(path.join(paths.appBuild, filePath), code);
+  const outputFilePath =
+    path.join(paths.appBuild,
+              path.join(path.dirname(filePath),
+                        path.basename(filePath, path.extname(filePath)) + '.js'))
+  // TODO: Create 1:1 copy with .js.flow extension for flow support
+  fs.writeFileSync(outputFilePath, code);
+  return outputFilePath
 }
 
 function copyAsset (filePath) {
@@ -36,8 +42,8 @@ function processFile (filePath) {
   if (/\.(es6|jsx?)$/.test(filePath)) {
 
     fs.mkdirpSync(path.parse(path.join(paths.appBuild, filePath)).dir);
-    transformWithBabel(filePath);
-    console.log(path.join(paths.appSrc, filePath) + ' -> ' + path.join(paths.appBuild, filePath));
+    const outputPath = transformWithBabel(filePath);
+    console.log(path.join(paths.appSrc, filePath) + ' -> ' + outputPath);
 
   } else if (/\.(s?css|svg|json|ico|jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$/.test(filePath)) {
 

--- a/packages/react-scripts/utils/loadEnv.js
+++ b/packages/react-scripts/utils/loadEnv.js
@@ -2,6 +2,9 @@
 var fs = require('fs');
 var path = require('path');
 var dotenv = require('dotenv');
+var paths = require('../config/paths');
+var pkg = require(paths.appPackageJson);
+var git = require('git-rev-sync');
 
 var env = process.env.NODE_ENV;
 var appDirectory = fs.realpathSync(process.cwd());
@@ -10,6 +13,11 @@ var appDirectory = fs.realpathSync(process.cwd());
 // There are some scenarios where we need to explicitly know that
 // we are in a staging environment.
 process.env.TC_ENV = env;
+
+process.env.TC_CLIENT_APP_NAME = pkg.name,
+process.env.TC_CLIENT_BUILD_COMMIT = git.long(),
+process.env.TC_CLIENT_BUILD_TIME = (new Date()).toISOString()
+
 
 // dotenv will not change values that are already set, sourcing the
 // overrides firsts means they will beat anything in the default


### PR DESCRIPTION
Before this, build 5 would keep the original file extensions for babeled files. (`src/App.es6 -> build/App.es6`).

That's bad because webpack and node and all of those things don't default to looking for those file extensions in `node_modules`.

This rewrites all babeled file's extensions to `.js` and should make it so we can migrate `@trunkclub/web` and other modules that are using the `.es6` and `.jsx` extensions.

(Also in here is a change to move where the `TC_CLIENT_*` stuff gets added. This makes it so those variables are available in tests.)