### PR TITLE
Enable overriding of the project directory with an environment variable

### DIFF
--- a/packages/react-scripts/config/paths.js
+++ b/packages/react-scripts/config/paths.js
@@ -14,7 +14,7 @@ var fs = require('fs');
 
 // Make sure any symlinks in the project folder are resolved:
 // https://github.com/facebookincubator/create-react-app/issues/637
-var appDirectory = fs.realpathSync(process.cwd());
+var appDirectory = process.env.PROJECT_DIR || fs.realpathSync(process.cwd());
 function resolveApp(relativePath) {
   return path.resolve(appDirectory, relativePath);
 }
@@ -81,7 +81,7 @@ module.exports = {
 };
 
 // config before publish: we're in ./packages/react-scripts/config/
-if (__dirname.indexOf(path.join('packages', 'react-scripts', 'config')) !== -1) {
+if (!process.env.PROJECT_DIR && __dirname.indexOf(path.join('packages', 'react-scripts', 'config')) !== -1) {
   module.exports = {
     appBuild: resolveOwn('../../../build'),
     appPublic: resolveOwn('../template/public'),


### PR DESCRIPTION
#### What

Gives us the option to set a custom project directory for `@trunkclub/build` to use by setting an environment variable `PROJECT_DIR`.

#### Why

We were unable to use `@trunkclub/build` against a project when it was locally linked. This hindered the development feedback loop of this project.

Additionally, we can now use a single install of this tool to build all modules in a monorepo.

#### Who

@zperrault @jblock @eanplatter @littleredninja 