### PR TITLE
More readable output for the build-module task

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trunkclub/build",
-  "version": "5.10.1",
+  "version": "5.11.0",
   "upstream-version": "0.8.4",
   "description": "Configuration and scripts for Create React App. Fork maintained by Trunk Club",
   "repository": "trunkclub/create-react-app",

--- a/packages/react-scripts/scripts/build-module.js
+++ b/packages/react-scripts/scripts/build-module.js
@@ -6,6 +6,7 @@ var chokidar = require('chokidar');
 var transformFileSync = require('babel-core').transformFileSync;
 var spawn = require('cross-spawn');
 var paths = require('../config/paths');
+const chalk = require('chalk')
 
 function lint () {
   return spawn.sync('node', [require.resolve('./lint')], {stdio: 'inherit'});
@@ -43,13 +44,21 @@ function processFile (filePath) {
 
     fs.mkdirpSync(path.parse(path.join(paths.appBuild, filePath)).dir);
     const outputPath = transformWithBabel(filePath);
-    console.log(path.join(paths.appSrc, filePath) + ' -> ' + outputPath);
+    console.log(
+      chalk.cyan.bgBlack('BABEL') +
+      ' [' + chalk.green(filePath) + '] ' +
+      chalk.gray(path.join(paths.appSrc, filePath) + ' -> ' + outputPath)
+    );
 
   } else if (/\.(s?css|svg|json|ico|jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$/.test(filePath)) {
 
     fs.mkdirpSync(path.parse(path.join(paths.appBuild, filePath)).dir);
     copyAsset(filePath)
-    console.log(path.join(paths.appSrc, filePath) + ' -> ' + path.join(paths.appBuild, filePath));
+    console.log(
+      chalk.magenta.bgBlack('COPY') +
+      ' [' + chalk.green(filePath) + '] ' +
+      chalk.gray(path.join(paths.appSrc, filePath) + ' -> ' + path.join(paths.appBuild, filePath))
+    );
 
   }
 }


### PR DESCRIPTION
#### What

Updates the terminal output of the `build-module` task to be more easily read at a glance.

**NEW**

![screenshot 2017-02-10 15 36 17](https://cloud.githubusercontent.com/assets/84348/22845111/ae4678c8-efa6-11e6-8361-f7123f4268be.png)

**OLD**

![screenshot 2017-02-10 15 36 45](https://cloud.githubusercontent.com/assets/84348/22845128/beae16da-efa6-11e6-8f80-7a2ae3754b0b.png)

#### Why

Developer Happiness™.

#### Who

@jblock @zperrault @littleredninja @alexbartling 