### PR TITLE
Create plugin to generate a file of Trunk Club module versions

### DIFF
--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -16,6 +16,7 @@ var CaseSensitivePathsPlugin = require('case-sensitive-paths-webpack-plugin');
 var InterpolateHtmlPlugin = require('@trunkclub/react-dev-utils/InterpolateHtmlPlugin');
 var WatchMissingNodeModulesPlugin = require('@trunkclub/react-dev-utils/WatchMissingNodeModulesPlugin');
 var ProgressBarPlugin = require('progress-bar-webpack-plugin');
+var TrunkClubVersionsPlugin = require('../utils/trunkclub-versions-plugin');
 var getClientEnvironment = require('./env');
 var path = require('path');
 var paths = require('./paths');
@@ -241,6 +242,12 @@ module.exports = {
     new HtmlWebpackPlugin({
       inject: true,
       template: paths.appHtml,
+    }),
+    // This will add a file to the build named 'tcversions.json' to assist
+    // with debugging apps that are in staging and production.
+    new TrunkClubVersionsPlugin({
+      packagePath: paths.appPackageJson,
+      modulesPath: paths.appNodeModules,
     }),
     // Makes some environment variables available to the JS code, for example:
     // if (process.env.NODE_ENV === 'development') { ... }. See `./env.js`.

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -16,6 +16,7 @@ var ExtractTextPlugin = require('extract-text-webpack-plugin');
 var ManifestPlugin = require('webpack-manifest-plugin');
 var InterpolateHtmlPlugin = require('@trunkclub/react-dev-utils/InterpolateHtmlPlugin');
 var BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
+var TrunkClubVersionsPlugin = require('../utils/trunkclub-versions-plugin');
 var url = require('url');
 var paths = require('./paths');
 var getClientEnvironment = require('./env');
@@ -279,6 +280,12 @@ module.exports = {
         minifyCSS: true,
         minifyURLs: true
       }
+    }),
+    // This will add a file to the build named 'tcversions.json' to assist
+    // with debugging apps that are in staging and production.
+    new TrunkClubVersionsPlugin({
+      packagePath: paths.appPackageJson,
+      modulesPath: paths.appNodeModules,
     }),
     // Makes some environment variables available to the JS code, for example:
     // if (process.env.NODE_ENV === 'production') { ... }. See `./env.js`.

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trunkclub/build",
-  "version": "5.11.0",
+  "version": "5.12.0",
   "upstream-version": "0.8.4",
   "description": "Configuration and scripts for Create React App. Fork maintained by Trunk Club",
   "repository": "trunkclub/create-react-app",

--- a/packages/react-scripts/utils/trunkclub-versions-plugin.js
+++ b/packages/react-scripts/utils/trunkclub-versions-plugin.js
@@ -3,10 +3,14 @@ const path = require('path');
 function getVersions(packagePath, modulesPath) {
   try {
     const pkg = require(packagePath);
-    const versions = Object.keys(pkg.dependencies)
+    const pkgNames = [].concat(
+      Object.keys(pkg.dependencies || {}),
+      Object.keys(pkg.devDependencies || {})
+    )
+    const versions = pkgNames
       .filter(name => name.startsWith('@trunkclub/'))
       .reduce((acc, name) => {
-        const modulePath = `${modulesPath}/${name}/package.json`;
+        const modulePath = path.join(modulesPath, name, 'package.json');
         try {
           return Object.assign({}, acc, {
             [name]: require(modulePath).version

--- a/packages/react-scripts/utils/trunkclub-versions-plugin.js
+++ b/packages/react-scripts/utils/trunkclub-versions-plugin.js
@@ -1,0 +1,50 @@
+const path = require('path');
+
+function getVersions(packagePath, modulesPath) {
+  try {
+    const pkg = require(packagePath);
+    const versions = Object.keys(pkg.dependencies)
+      .filter(name => name.startsWith('@trunkclub/'))
+      .reduce((acc, name) => {
+        const modulePath = `${modulesPath}/${name}/package.json`;
+        try {
+          return Object.assign({}, acc, {
+            [name]: require(modulePath).version
+          });
+        } catch (e) {
+          return acc;
+        }
+      }, {})
+    return Object.assign({}, { [pkg.name]: pkg.version }, versions);
+  } catch (e) {
+    return { error: `${e.name}: ${e.message}` };
+  }
+}
+
+function TrunkClubVersionsPlugin(options) {
+  if (!options || !options.packagePath || !options.modulesPath) {
+    throw new Error('Missing config for TrunkClubVersionsPlugin. Options `packagePath` and `modulesPath` are required.')
+  }
+
+  this.versionData = getVersions(options.packagePath, options.modulesPath);
+}
+
+TrunkClubVersionsPlugin.prototype.apply = function(compiler) {
+  const file = JSON.stringify(this.versionData);
+
+  compiler.plugin('emit', function(compilation, callback) {
+    // Add a file to the webpack build
+    compilation.assets['tcversions.json'] = {
+      source() {
+        return file;
+      },
+      size() {
+        return file.length;
+      }
+    };
+
+    callback();
+  });
+};
+
+module.exports = TrunkClubVersionsPlugin;


### PR DESCRIPTION
Adds a plugin for webpack that generates a `tcversions.json` file, which will be included in the webpack build output.

This file will display the versions of each `@trunkclub/....` package that is set as a dependency, as a way to help with debugging apps that are in production and staging.