### PR TITLE
Honeybadger deployment integrations

### DIFF
--- a/packages/react-scripts/bin/react-scripts.js
+++ b/packages/react-scripts/bin/react-scripts.js
@@ -15,6 +15,7 @@ function run (s) {
   case 'build-module':
   case 'lint':
   case 'publish':
+  case 'deploy':
     var result = spawn.sync(
       'node',
       [require.resolve('../scripts/' + s)].concat(args),

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trunkclub/build",
-  "version": "5.13.0-beta.2",
+  "version": "5.13.0-beta.3",
   "upstream-version": "0.8.4",
   "description": "Configuration and scripts for Create React App. Fork maintained by Trunk Club",
   "repository": "trunkclub/create-react-app",

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trunkclub/build",
-  "version": "5.13.0-beta.1",
+  "version": "5.13.0-beta.2",
   "upstream-version": "0.8.4",
   "description": "Configuration and scripts for Create React App. Fork maintained by Trunk Club",
   "repository": "trunkclub/create-react-app",

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trunkclub/build",
-  "version": "5.13.0-beta.3",
+  "version": "5.13.0",
   "upstream-version": "0.8.4",
   "description": "Configuration and scripts for Create React App. Fork maintained by Trunk Club",
   "repository": "trunkclub/create-react-app",

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trunkclub/build",
-  "version": "5.12.0",
+  "version": "5.13.0-beta.1",
   "upstream-version": "0.8.4",
   "description": "Configuration and scripts for Create React App. Fork maintained by Trunk Club",
   "repository": "trunkclub/create-react-app",

--- a/packages/react-scripts/scripts/deploy.js
+++ b/packages/react-scripts/scripts/deploy.js
@@ -20,6 +20,7 @@ if (process.env.TC_HONEYBADGER_KEY) {
     .end([ `deploy[environment]=${process.env.NODE_ENV}`
          , `deploy[revision]=${process.env.TC_CLIENT_BUILD_COMMIT}`
          , `deploy[local_username]=${process.env.CIRCLE_USERNAME}`
+         , `deploy[repository]=${process.env.CIRCLE_REPOSITORY_URL}`
          , `api_key=${process.env.TC_HONEYBADGER_KEY}`
          ].join('&'),
            res => {

--- a/packages/react-scripts/scripts/deploy.js
+++ b/packages/react-scripts/scripts/deploy.js
@@ -1,0 +1,31 @@
+const https = require('https');
+require('../utils/loadEnv');
+
+if (process.env.TC_HONEYBADGER_KEY) {
+  console.log('Notifying HoneyBadger of a deploy.')
+  https
+    .request({
+      protocol: 'https:',
+      host: 'api.honeybadger.io',
+      path: '/v1/deploys',
+      method: 'POST',
+
+    })
+    .on('error',
+        err => {
+          console.log('Failed to notify HoneyBadger of deploy.');
+          console.log(err);
+          process.exit(1);
+        })
+    .end([ `deploy[environment]=${process.env.NODE_ENV}`
+          , `deploy[revision]=${process.env.TC_CLIENT_BUILD_COMMIT}`
+          , `api_key=${process.env.TC_HONEYBADGER_KEY}`
+          ].join('&'),
+           res => {
+             console.log('HoneyBadger deployment notification successful.')
+             process.exit(0);
+           })
+} else {
+  console.log('TC_HONEYBADGER_KEY is not defined. Skipping HoneyBadger deployment notification.');
+  process.exit(0);
+}

--- a/packages/react-scripts/scripts/deploy.js
+++ b/packages/react-scripts/scripts/deploy.js
@@ -18,9 +18,10 @@ if (process.env.TC_HONEYBADGER_KEY) {
           process.exit(1);
         })
     .end([ `deploy[environment]=${process.env.NODE_ENV}`
-          , `deploy[revision]=${process.env.TC_CLIENT_BUILD_COMMIT}`
-          , `api_key=${process.env.TC_HONEYBADGER_KEY}`
-          ].join('&'),
+         , `deploy[revision]=${process.env.TC_CLIENT_BUILD_COMMIT}`
+         , `deploy[local_username]=${process.env.CIRCLE_USERNAME}`
+         , `api_key=${process.env.TC_HONEYBADGER_KEY}`
+         ].join('&'),
            res => {
              console.log('HoneyBadger deployment notification successful.')
              process.exit(0);


### PR DESCRIPTION
Adds an new script to run post deployment to notify honeybadger of the deploy.

Uses http://docs.honeybadger.io/guides/api.html#deployment-tracking-api

Here's what it looks like in honeybadger: https://app.honeybadger.io/projects/48901/deploys

/cc @trunkclub/ui 