### PR TITLE
Clear old build artifacts before building a module

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trunkclub/build",
-  "version": "5.13.0",
+  "version": "5.14.0",
   "upstream-version": "0.8.4",
   "description": "Configuration and scripts for Create React App. Fork maintained by Trunk Club",
   "repository": "trunkclub/create-react-app",

--- a/packages/react-scripts/scripts/build-module.js
+++ b/packages/react-scripts/scripts/build-module.js
@@ -73,9 +73,13 @@ if (outDirIdx !== -1) {
   paths.appBuild = path.resolve(paths.appBuild, '..', args[outDirIdx + 1])
 }
 
-var result = lint();
 // Clear previous build artifacts before we start
-fs.removeSync(paths.appBuild);
+var shouldClean = args.indexOf('--clean') !== -1
+if (shouldClean) {
+  fs.removeSync(paths.appBuild);
+}
+
+var result = lint();
 fs.walkSync(paths.appSrc).forEach(function (filePath) {
   processFile(path.relative(paths.appSrc, filePath));
 });

--- a/packages/react-scripts/scripts/build-module.js
+++ b/packages/react-scripts/scripts/build-module.js
@@ -74,6 +74,8 @@ if (outDirIdx !== -1) {
 }
 
 var result = lint();
+// Clear previous build artifacts before we start
+fs.removeSync(paths.appBuild);
 fs.walkSync(paths.appSrc).forEach(function (filePath) {
   processFile(path.relative(paths.appSrc, filePath));
 });


### PR DESCRIPTION
Clears out the build folder before we build a module to ensure delete/renamed files don't persist.