### PR TITLE
Update to our latest eslint config

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trunkclub/build",
-  "version": "5.14.0",
+  "version": "5.15.0",
   "upstream-version": "0.8.4",
   "description": "Configuration and scripts for Create React App. Fork maintained by Trunk Club",
   "repository": "trunkclub/create-react-app",
@@ -29,7 +29,7 @@
     "tcweb-build": "./bin/react-scripts.js"
   },
   "dependencies": {
-    "@trunkclub/eslint-config": "2.0.0",
+    "@trunkclub/eslint-config": "3.0.0",
     "@trunkclub/react-dev-utils": "1.1.0",
     "autoprefixer": "6.5.1",
     "babel-cli": "6.18.0",
@@ -53,11 +53,12 @@
     "elm-webpack-loader": "3.0.6",
     "eslint": "3.8.1",
     "eslint-loader": "1.6.0",
-    "eslint-plugin-flowtype-errors": "1.5.0",
+    "eslint-plugin-flowtype-errors": "3.0.0",
     "eslint-plugin-react": "6.4.1",
     "extract-text-webpack-plugin": "1.0.1",
     "file-loader": "0.9.0",
     "filesize": "3.3.0",
+    "flow-bin": "0.40.0",
     "fs-extra": "1.0.0",
     "git-rev-sync": "1.8.0",
     "gzip-size": "3.0.0",


### PR DESCRIPTION
* Updates to our latest eslint config
* We are now managing the flow version here instead of implicitly via the eslint-plugin-flowtype-errors package.