### PR TITLE
Produce Flow files

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -58,7 +58,7 @@
     "extract-text-webpack-plugin": "1.0.1",
     "file-loader": "0.9.0",
     "filesize": "3.3.0",
-    "flow-bin": "0.41.0",
+    "flow-bin": "0.42.0",
     "fs-extra": "1.0.0",
     "git-rev-sync": "1.8.0",
     "gzip-size": "3.0.0",

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trunkclub/build",
-  "version": "5.17.1",
+  "version": "5.18.0",
   "upstream-version": "0.8.4",
   "description": "Configuration and scripts for Create React App. Fork maintained by Trunk Club",
   "repository": "trunkclub/create-react-app",

--- a/packages/react-scripts/scripts/build-module.js
+++ b/packages/react-scripts/scripts/build-module.js
@@ -44,7 +44,7 @@ function transformWithBabel (filePath) {
   // Copy the source file as a Flow declaration file
   const  outputFlowFilePath = outputFilePath + '.flow'
   fs.copySync(srcFile, outputFlowFilePath)
-  fancyLog(chalk.yellow, 'FLOW', filePath, srcFile, outputFlowFilePath)
+  fancyLog(chalk.yellow, 'FLOW', filePath + '.flow', srcFile, outputFlowFilePath)
   return outputFilePath
 }
 


### PR DESCRIPTION
When building a module, this will also copy the non-transpile source file to the output directory as `NAME.js.flow`. Flow takes preference of this declaration file over the corresponding `NAME.js`, which has had the Flow annotations removed.

This also upgrades Flow to v0.42

![screenshot 2017-03-28 17 28 23](https://cloud.githubusercontent.com/assets/84348/24430525/9b1e7f70-13dc-11e7-8284-9f1ada787703.png)
