### PR TITLE
build-module: Lint files after transpiling instead of before

### DIFF
--- a/packages/react-scripts/scripts/build-module.js
+++ b/packages/react-scripts/scripts/build-module.js
@@ -84,10 +84,10 @@ if (shouldClean) {
   fs.removeSync(paths.appBuild);
 }
 
-var result = lint();
 fs.walkSync(paths.appSrc).forEach(function (filePath) {
   processFile(path.relative(paths.appSrc, filePath));
 });
+var result = lint();
 
 var isWatch = args.indexOf('-w') !== -1 || args.indexOf('--watch') !== -1
 if (!isWatch) process.exit(result.status);
@@ -102,7 +102,7 @@ var watcher = chokidar.watch([
 
 watcher.on('all', function (event, filePath) {
   if (event === 'add' || event === 'change') {
-    lint();
     processFile(filePath);
+    lint();
   }
 })


### PR DESCRIPTION
Linter errors get lost in large projects like @trunkclub/web because the result is printed to the terminal before all of the files are processed. This makes failing builds more cryptic.

This simply switches the order of the linting and file processing tasks so that we lint after the file(s) are processed. Doing this will print the linter results at the end, thus ensuring it is visible.