### PR TITLE
Enable colocation of tests

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trunkclub/build",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "upstream-version": "0.8.4",
   "description": "Configuration and scripts for Create React App. Fork maintained by Trunk Club",
   "repository": "trunkclub/create-react-app",

--- a/packages/react-scripts/scripts/build-module.js
+++ b/packages/react-scripts/scripts/build-module.js
@@ -84,10 +84,10 @@ if (shouldClean) {
   fs.removeSync(paths.appBuild);
 }
 
+var result = lint();
 fs.walkSync(paths.appSrc).forEach(function (filePath) {
   processFile(path.relative(paths.appSrc, filePath));
 });
-var result = lint();
 
 var isWatch = args.indexOf('-w') !== -1 || args.indexOf('--watch') !== -1
 if (!isWatch) process.exit(result.status);
@@ -102,7 +102,7 @@ var watcher = chokidar.watch([
 
 watcher.on('all', function (event, filePath) {
   if (event === 'add' || event === 'change') {
-    processFile(filePath);
     lint();
+    processFile(filePath);
   }
 })

--- a/packages/react-scripts/scripts/build-module.js
+++ b/packages/react-scripts/scripts/build-module.js
@@ -84,10 +84,10 @@ if (shouldClean) {
   fs.removeSync(paths.appBuild);
 }
 
-var result = lint();
 fs.walkSync(paths.appSrc).forEach(function (filePath) {
   processFile(path.relative(paths.appSrc, filePath));
 });
+var result = lint();
 
 var isWatch = args.indexOf('-w') !== -1 || args.indexOf('--watch') !== -1
 if (!isWatch) process.exit(result.status);
@@ -102,7 +102,7 @@ var watcher = chokidar.watch([
 
 watcher.on('all', function (event, filePath) {
   if (event === 'add' || event === 'change') {
-    lint();
     processFile(filePath);
+    lint();
   }
 })

--- a/packages/react-scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/utils/createJestConfig.js
@@ -20,7 +20,7 @@ module.exports = (resolve, rootDir, isEjecting) => {
   // TODO: I don't know if it's safe or not to just use / as path separator
   // in Jest configs. We need help from somebody with Windows to determine this.
   const config = {
-    testPathDirs: [ 'spec' ],
+    testPathDirs: [ 'spec', 'src' ],
     testRegex: '.*spec\\.(es6|js)$',
     moduleDirectories: [ 'src', 'node_modules' ],
     moduleFileExtensions: [ 'js', 'json', 'es6', 'jsx' ],


### PR DESCRIPTION
Test files can now be colocated with their corresponding source files. Tests should end in `.spec.js` and be located in a `__tests__` folder within the same directory as the module being tested.

Example:

```
src/
    components/
        __tests__/
            MyComponent.spec.js
            OtherComponent.spec.js
        MyComponent.js
        OtherComponent.js
    state/
        example/
            __tests__/
                actions.spec.js
                reducer.spec.js
                sagas.spec.js
            actions.js
            reducer.js
            sagas.js
```

This will not affect existing tests located in the `/spec` directory.