### PR TITLE
Fix the eslint config when using the CLI

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trunkclub/build",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "upstream-version": "0.8.4",
   "description": "Configuration and scripts for Create React App. Fork maintained by Trunk Club",
   "repository": "trunkclub/create-react-app",

--- a/packages/react-scripts/scripts/lint.js
+++ b/packages/react-scripts/scripts/lint.js
@@ -7,6 +7,12 @@ var config = require('@trunkclub/eslint-config');
 config.fix = true;
 config.extensions = ['.js', '.jsx', '.es6'];
 
+// CLIEngine env config differs from .eslintrc
+// http://eslint.org/docs/developer-guide/nodejs-api#cliengine
+config.envs = Object
+  .keys(config.env)
+  .filter(envKey => config.env[envKey])
+
 var eslint = new CLIEngine(config);
 
 var report = eslint.executeOnFiles([paths.appSrc]);


### PR DESCRIPTION
The config for eslint's CLIEngine differs slightly than the one used for `.eslintrc`.

We are importing our .eslintrc config, so we need to coerce it into the correct format.

http://eslint.org/docs/developer-guide/nodejs-api#cliengine
