### PR TITLE
Allow custom NODE_ENV in start and build scripts

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trunkclub/build",
-  "version": "9.0.0",
+  "version": "9.0.1",
   "upstream-version": "1.0.7",
   "description": "Configuration and scripts for Create React App. Fork maintained by Trunk Club",
   "repository": "trunkclub/create-react-app",

--- a/packages/react-scripts/scripts/build-module.js
+++ b/packages/react-scripts/scripts/build-module.js
@@ -16,7 +16,6 @@ const fs = require('fs-extra')
 const walkSync = require('klaw-sync')
 const chokidar = require('chokidar')
 const transformFileSync = require('babel-core').transformFileSync
-const spawn = require('cross-spawn')
 const paths = require('../config/paths')
 const chalk = require('chalk')
 

--- a/packages/react-scripts/scripts/build.js
+++ b/packages/react-scripts/scripts/build.js
@@ -12,7 +12,7 @@
 
 // Do this as the first thing so that any code reading it knows the right env.
 process.env.BABEL_ENV = 'production';
-process.env.NODE_ENV = 'production';
+process.env.NODE_ENV = process.env.NODE_ENV || 'production';
 
 // Makes the script crash on unhandled rejections instead of silently
 // ignoring them. In the future, promise rejections that are not handled will

--- a/packages/react-scripts/scripts/start.js
+++ b/packages/react-scripts/scripts/start.js
@@ -12,7 +12,7 @@
 
 // Do this as the first thing so that any code reading it knows the right env.
 process.env.BABEL_ENV = 'development';
-process.env.NODE_ENV = 'development';
+process.env.NODE_ENV = process.env.NODE_ENV || 'development';
 
 // Makes the script crash on unhandled rejections instead of silently
 // ignoring them. In the future, promise rejections that are not handled will


### PR DESCRIPTION
Upstream changes were hardcoding the NODE_ENV in the `start` and `build` scripts. This allows us to pass in a custom env like `staging`.

@zperrault @eanplatter @johnromas 