### PR TITLE
Switch back to hardcoded NODE_ENV, use TC_ENV for loading env files

### DIFF
--- a/packages/react-scripts/config/env.js
+++ b/packages/react-scripts/config/env.js
@@ -26,16 +26,18 @@ if (!NODE_ENV) {
   );
 }
 
+const TC_ENV = process.env.TC_ENV
+
 // https://github.com/bkeepers/dotenv#what-other-env-files-can-i-use
 var dotenvFiles = [
-  `${paths.appPath}/${NODE_ENV}.env.overrides`,
-  `${paths.appPath}/${NODE_ENV}.env`,
-  `${paths.dotenv}.${NODE_ENV}.local`,
-  `${paths.dotenv}.${NODE_ENV}`,
+  `${paths.appPath}/${TC_ENV}.env.overrides`,
+  `${paths.appPath}/${TC_ENV}.env`,
+  `${paths.dotenv}.${TC_ENV}.local`,
+  `${paths.dotenv}.${TC_ENV}`,
   // Don't include `.env.local` for `test` environment
   // since normally you expect tests to produce the same
   // results for everyone
-  NODE_ENV !== 'test' && `${paths.dotenv}.local`,
+  TC_ENV !== 'test' && `${paths.dotenv}.local`,
   paths.dotenv,
 ].filter(Boolean);
 

--- a/packages/react-scripts/config/env/getTCEnv.js
+++ b/packages/react-scripts/config/env/getTCEnv.js
@@ -9,7 +9,7 @@ var env = process.env.NODE_ENV;
 // CRA assumes two environments: development or production.
 // There are some scenarios where we need to explicitly know that
 // we are in a staging environment.
-process.env.TC_ENV = env;
+process.env.TC_ENV = process.env.TC_ENV || env;
 process.env.TC_CLIENT_APP_NAME = pkg.name;
 process.env.TC_CLIENT_BUILD_COMMIT = git.long();
 process.env.TC_CLIENT_BUILD_TIME = (new Date()).toISOString();

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trunkclub/build",
-  "version": "9.0.1",
+  "version": "9.0.2",
   "upstream-version": "1.0.7",
   "description": "Configuration and scripts for Create React App. Fork maintained by Trunk Club",
   "repository": "trunkclub/create-react-app",

--- a/packages/react-scripts/scripts/build.js
+++ b/packages/react-scripts/scripts/build.js
@@ -11,8 +11,9 @@
 'use strict';
 
 // Do this as the first thing so that any code reading it knows the right env.
+process.env.TC_ENV = process.env.NODE_ENV || 'production';
 process.env.BABEL_ENV = 'production';
-process.env.NODE_ENV = process.env.NODE_ENV || 'production';
+process.env.NODE_ENV = 'production';
 
 // Makes the script crash on unhandled rejections instead of silently
 // ignoring them. In the future, promise rejections that are not handled will

--- a/packages/react-scripts/scripts/start.js
+++ b/packages/react-scripts/scripts/start.js
@@ -12,7 +12,7 @@
 
 // Do this as the first thing so that any code reading it knows the right env.
 process.env.BABEL_ENV = 'development';
-process.env.NODE_ENV = process.env.NODE_ENV || 'development';
+process.env.NODE_ENV = 'development';
 
 // Makes the script crash on unhandled rejections instead of silently
 // ignoring them. In the future, promise rejections that are not handled will


### PR DESCRIPTION
* Switches back to the hardcoded `NODE_ENV` in the build & start scripts
* Uses `TC_ENV` to determine which `.env` files to load

Doing this will allow us to load custom `.env` files without messing with `NODE_ENV` itself.

@zperrault 