### PR TITLE
Fix flexbox and importloaders

### DIFF
--- a/packages/react-scripts/config/webpack/cssLoaders.js
+++ b/packages/react-scripts/config/webpack/cssLoaders.js
@@ -7,7 +7,7 @@ module.exports = function getCSSLoaders(cssLoaderOpts) {
     {
       loader: require.resolve('css-loader'),
       options: Object.assign({}, {
-        importLoaders: 1,
+        importLoaders: 2,
         sourceMap: true,
       }, (cssLoaderOpts || {})),
     },

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -73,7 +73,7 @@
     "node-sass": "^4.5.3",
     "object-assign": "4.1.1",
     "path-exists": "2.1.0",
-    "postcss-flexbugs-fixes": "3.0.0",
+    "postcss-flexbugs-fixes": "3.2.0",
     "postcss-loader": "2.0.5",
     "prettier": "^1.4.4",
     "progress-bar-webpack-plugin": "1.9.0",

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trunkclub/build",
-  "version": "9.0.2",
+  "version": "9.0.3",
   "upstream-version": "1.0.7",
   "description": "Configuration and scripts for Create React App. Fork maintained by Trunk Club",
   "repository": "trunkclub/create-react-app",


### PR DESCRIPTION
### Bugfixes

#### Flexbox

Updates the `postcss-flexbugs-fixes` dependency since it was transpiling incorrectly.

#### Sass Imports

Increases the css-loader `importLoaders` property from `1` to `2` since we are using 2 loaders prior to css-loader: sass-loader & postcss-loader.

This _should_ resolve the import errors we occasionally encounter.

@dannyfreed @johnromas 