### PR TITLE
Es-lint report warnings instead of errors in dev

### DIFF
--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -154,6 +154,7 @@ module.exports = {
               },
               ignore: false,
               useEslintrc: false,
+              emitWarning: true,
               // @remove-on-eject-end
             },
             loader: require.resolve('eslint-loader'),

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trunkclub/build",
-  "version": "9.0.3",
+  "version": "9.0.4",
   "upstream-version": "1.0.7",
   "description": "Configuration and scripts for Create React App. Fork maintained by Trunk Club",
   "repository": "trunkclub/create-react-app",


### PR DESCRIPTION
Pass option to the es-lint loader to report warnings instead of errors in dev.

Tested locally and seems to work fine.

@zperrault @iamlacroix 