### PR TITLE
Pacify node version check

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trunkclub/build",
-  "version": "10.0.0",
+  "version": "10.1.0",
   "upstream-version": "1.0.7",
   "description": "Configuration and scripts for Create React App. Fork maintained by Trunk Club",
   "repository": "trunkclub/create-react-app",

--- a/packages/react-scripts/utils/checkNodeVersion.js
+++ b/packages/react-scripts/utils/checkNodeVersion.js
@@ -1,28 +1,34 @@
 // Largely adapted from https://github.com/trunkclub/tcweb-build/blob/master/src/cli/validators/node-validator.es6
-var cp = require('child_process');
-var path = require('path');
-var fs = require('fs');
-var chalk = require('chalk');
+var cp = require('child_process')
+var path = require('path')
+var fs = require('fs')
+var chalk = require('chalk')
 
 function clean(str) {
-  return str.replace(/\n/, '');
+  return str.replace(/\n/, '')
 }
 
-function checkNodeVersion (dir) {
-  var actualVersion = clean(cp.execSync('node -v', { env: process.env }).toString('utf8'));
-  var nvmrcVersion = clean(fs.readFileSync(path.join(dir, '.nvmrc'), 'utf8'));
+function checkNodeVersion(dir) {
+  var actualVersion = clean(
+    cp.execSync('node -v', { env: process.env }).toString('utf8')
+  )
+  var nvmrcVersion = clean(fs.readFileSync(path.join(dir, '.nvmrc'), 'utf8'))
 
   if (actualVersion !== nvmrcVersion) {
-    console.log();
-    console.log(chalk.red('Node versions do not match!'));
-    console.log();
-    console.log('  Exepected: ' + nvmrcVersion);
-    console.log('  Actual:    ' + actualVersion);
-    console.log();
-    console.log('Run `nvm install` and try again');
-    console.log();
-    process.exit(1);
+    console.log()
+    console.log(chalk.yellow('WARNING: Node versions do not match!'))
+    console.log()
+    console.log('  Exepected: ' + nvmrcVersion)
+    console.log('  Actual:    ' + actualVersion)
+    console.log()
+    console.log(
+      'If you run into issues during development, this may be the cause.'
+    )
+    console.log(
+      'Running `nvm install` will install and select the correct version of node.'
+    )
+    console.log()
   }
 }
 
-module.exports = checkNodeVersion;
+module.exports = checkNodeVersion


### PR DESCRIPTION
[@jblock asked in Slack](https://trunkclub.slack.com/archives/C0285UCH6/p1507066088000239) about removing the node version check from build.

I thought this was a nice middle ground that would still let you know if you weren't using the node version specified but wouldn't stop you from doing so.