### PR TITLE
fix dev css module class name

### DIFF
--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -241,7 +241,7 @@ module.exports = {
         test: /\.module\.s?css$/,
         use: [require.resolve('style-loader')].concat(getCSSLoaders({
           modules: true,
-          localidentname: '[path][name]__[local]--[hash:base64:8]',
+          localIdentName: '[path][name]__[local]--[hash:base64:8]',
         })),
       },
       {


### PR DESCRIPTION
Typo in CSS loader option config: [Docs](https://github.com/webpack-contrib/css-loader#options)

The change allows the css-loader to display the css module source/name in dev environment