### PR TITLE
Expose additional data to tcversions.json and process.env

### DIFF
--- a/packages/react-scripts/config/env/getTCEnv.js
+++ b/packages/react-scripts/config/env/getTCEnv.js
@@ -11,5 +11,6 @@ var env = process.env.NODE_ENV;
 // we are in a staging environment.
 process.env.TC_ENV = process.env.TC_ENV || env;
 process.env.TC_CLIENT_APP_NAME = pkg.name;
+process.env.TC_CLIENT_APP_VERSION = pkg.version;
 process.env.TC_CLIENT_BUILD_COMMIT = git.long();
 process.env.TC_CLIENT_BUILD_TIME = (new Date()).toISOString();

--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -19,7 +19,7 @@ const WatchMissingNodeModulesPlugin = require('@trunkclub/react-dev-utils/WatchM
 const eslintFormatter = require('@trunkclub/react-dev-utils/eslintFormatter');
 const ModuleScopePlugin = require('@trunkclub/react-dev-utils/ModuleScopePlugin');
 const ProgressBarPlugin = require('progress-bar-webpack-plugin');
-const TrunkClubVersionsPlugin = require('../utils/trunkclub-versions-plugin');
+const TrunkClubVersionsPlugin = require('../utils/trunkclubVersionsPlugin');
 const getClientEnvironment = require('./env');
 const paths = require('./paths');
 

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -23,7 +23,7 @@ const paths = require('./paths');
 const getClientEnvironment = require('./env');
 
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
-const TrunkClubVersionsPlugin = require('../utils/trunkclub-versions-plugin');
+const TrunkClubVersionsPlugin = require('../utils/trunkclubVersionsPlugin');
 const LodashModuleReplacementPlugin = require('lodash-webpack-plugin');
 const getCSSLoaders = require('./webpack/cssLoaders');
 

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trunkclub/build",
-  "version": "10.1.0",
+  "version": "10.2.0",
   "upstream-version": "1.0.7",
   "description": "Configuration and scripts for Create React App. Fork maintained by Trunk Club",
   "repository": "trunkclub/create-react-app",

--- a/packages/react-scripts/utils/trunkclubVersionsPlugin.js
+++ b/packages/react-scripts/utils/trunkclubVersionsPlugin.js
@@ -1,6 +1,8 @@
 'use strict'
 
 const path = require('path')
+const git = require('git-rev-sync')
+const commit = git.long()
 
 function getVersions(packagePath, modulesPath) {
   try {
@@ -21,7 +23,12 @@ function getVersions(packagePath, modulesPath) {
           return acc
         }
       }, {})
-    return Object.assign({}, { [pkg.name]: pkg.version }, versions)
+    return {
+      name: pkg.name,
+      version: pkg.version,
+      commit,
+      dependencies: versions,
+    }
   } catch (e) {
     return { error: `${e.name}: ${e.message}` }
   }

--- a/packages/react-scripts/utils/trunkclubVersionsPlugin.js
+++ b/packages/react-scripts/utils/trunkclubVersionsPlugin.js
@@ -1,8 +1,10 @@
-const path = require('path');
+'use strict'
+
+const path = require('path')
 
 function getVersions(packagePath, modulesPath) {
   try {
-    const pkg = require(packagePath);
+    const pkg = require(packagePath)
     const pkgNames = [].concat(
       Object.keys(pkg.dependencies || {}),
       Object.keys(pkg.devDependencies || {})
@@ -10,45 +12,47 @@ function getVersions(packagePath, modulesPath) {
     const versions = pkgNames
       .filter(name => name.startsWith('@trunkclub/'))
       .reduce((acc, name) => {
-        const modulePath = path.join(modulesPath, name, 'package.json');
+        const modulePath = path.join(modulesPath, name, 'package.json')
         try {
           return Object.assign({}, acc, {
-            [name]: require(modulePath).version
-          });
+            [name]: require(modulePath).version,
+          })
         } catch (e) {
-          return acc;
+          return acc
         }
       }, {})
-    return Object.assign({}, { [pkg.name]: pkg.version }, versions);
+    return Object.assign({}, { [pkg.name]: pkg.version }, versions)
   } catch (e) {
-    return { error: `${e.name}: ${e.message}` };
+    return { error: `${e.name}: ${e.message}` }
   }
 }
 
 function TrunkClubVersionsPlugin(options) {
   if (!options || !options.packagePath || !options.modulesPath) {
-    throw new Error('Missing config for TrunkClubVersionsPlugin. Options `packagePath` and `modulesPath` are required.')
+    throw new Error(
+      'Missing config for TrunkClubVersionsPlugin. Options `packagePath` and `modulesPath` are required.'
+    )
   }
 
-  this.versionData = getVersions(options.packagePath, options.modulesPath);
+  this.versionData = getVersions(options.packagePath, options.modulesPath)
 }
 
 TrunkClubVersionsPlugin.prototype.apply = function(compiler) {
-  const file = JSON.stringify(this.versionData);
+  const file = JSON.stringify(this.versionData)
 
   compiler.plugin('emit', function(compilation, callback) {
     // Add a file to the webpack build
     compilation.assets['tcversions.json'] = {
       source() {
-        return file;
+        return file
       },
       size() {
-        return file.length;
-      }
-    };
+        return file.length
+      },
+    }
 
-    callback();
-  });
-};
+    callback()
+  })
+}
 
-module.exports = TrunkClubVersionsPlugin;
+module.exports = TrunkClubVersionsPlugin


### PR DESCRIPTION
**This PR includes some prettier changes, so use this diff to view the changes: https://github.com/trunkclub/tcweb-build/pull/101/commits/4a604a1490444361d0883b7c4c55e13dfc35586d**

* [tcversions.json](https://sales.trunkclub.com/stylist_app/tcversions.json) will include the app name, app version, and git commit SHA. See below for example output.
* `process.env` now also exposes a variable `TC_CLIENT_APP_VERSION`.

Sample of the updated tcversions.json output:

```json
{
  "name": "stylist_app",
  "version": "1.41.0",
  "commit": "e78860846358cd5d80ac7ff7e3beaa5d0f34029e",
  "dependencies": {
    "@trunkclub/api": "3.0.1",
    "@trunkclub/data-stream": "1.6.0",
    "@trunkclub/integrated-member-profile": "2.7.0",
    "@trunkclub/logger": "1.0.0",
    "@trunkclub/modal-manager": "1.0.0",
    "@trunkclub/react-layer": "1.0.2",
    "@trunkclub/request": "2.0.1",
    "@trunkclub/runtime": "1.2.1",
    "@trunkclub/sales-configure-away-message": "0.1.1",
    "@trunkclub/sales-core": "0.13.0",
    "@trunkclub/scss-vars": "1.3.0",
    "@trunkclub/splunk-layer-monitor": "1.1.3",
    "@trunkclub/web": "13.6.0",
    "@trunkclub/build": "10.2.0-alpha.0",
    "@trunkclub/flowconfig": "1.1.0"
  }
}
```